### PR TITLE
Hotfix: GitHub Pages deploy broken on main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # packages/cli/src/index.ts statically imports a generated,
+      # gitignored ./manifest.json — build:cli-manifest writes it, reading
+      # from packages/registry/dist, which build:packages produces. Without
+      # these first, `next build`'s typecheck (which pulls every package's
+      # .ts/.tsx in, cli included) fails with "Cannot find module
+      # './manifest.json'". verify-release.mjs already does this ordering
+      # for the CI release-gates job; this deploy workflow needs the same
+      # fix independently since it calls `npm run build` directly rather
+      # than going through verify:release.
+      - name: Build package manifests
+        run: |
+          npm run build:packages
+          npm run build:cli-manifest
+
       - name: Build static website
         run: npm run build
 


### PR DESCRIPTION
## Summary

**Urgent — the live site's deploy is currently broken.** Merging #1 fixed the missing-CLI-manifest ordering for CI's release-gates job (which goes through `verify-release.mjs`), but `.github/workflows/pages.yml` calls `npm run build` directly — so the same `Cannot find module './manifest.json'` failure that blocked CI before also broke the actual deploy workflow, independently, the moment #1 landed. See the failed run: https://github.com/florash/Pinky-UI/actions/runs/32091315424

The live site is stuck serving whatever commit deployed successfully before #1, until this merges and a new deploy runs.

## Fix

Added the same `build:packages` → `build:cli-manifest` step before the website build in `pages.yml`, matching `verify-release.mjs`'s existing fix.

## Verification

Reproduced the exact deploy command locally: deleted `packages/cli/src/manifest.json` and every package's `dist/`, then ran the exact sequence `pages.yml` now runs, including the exact env vars (`NEXT_PUBLIC_SITE_URL=https://florash.github.io NEXT_PUBLIC_BASE_PATH=/Pinky-UI NEXT_PUBLIC_STATIC_EXPORT=true`). Succeeds. `typecheck` and full test suite (259 tests) also clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)