### PR TITLE
fix: unify the static-export build path between CI and Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,22 +32,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # packages/cli/src/index.ts statically imports a generated,
-      # gitignored ./manifest.json — build:cli-manifest writes it, reading
-      # from packages/registry/dist, which build:packages produces. Without
-      # these first, `next build`'s typecheck (which pulls every package's
-      # .ts/.tsx in, cli included) fails with "Cannot find module
-      # './manifest.json'". verify-release.mjs already does this ordering
-      # for the CI release-gates job; this deploy workflow needs the same
-      # fix independently since it calls `npm run build` directly rather
-      # than going through verify:release.
-      - name: Build package manifests
-        run: |
-          npm run build:packages
-          npm run build:cli-manifest
-
+      # scripts/build-static-site.mjs runs build:packages -> build:cli-manifest
+      # -> the static export build, in that order. Skipping the first two
+      # fails typecheck with "Cannot find module './manifest.json'" since
+      # packages/cli/src/index.ts statically imports that generated,
+      # gitignored file. scripts/verify-release.mjs's assertStaticExportBuild()
+      # runs this exact same script for the CI release-gates job.
       - name: Build static website
-        run: npm run build
+        run: npm run build:static-site
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build:packages": "node scripts/build-packages.mjs",
     "build:cli-manifest": "node scripts/build-cli-manifest.mjs",
     "build:cli": "npm run build:packages && npm run build:cli-manifest && node scripts/build-cli.mjs",
+    "build:static-site": "node scripts/build-static-site.mjs",
     "verify:metadata": "node scripts/verify-metadata.mjs",
     "verify:orphans": "node scripts/check-orphans.mjs",
     "verify:nested-anchors": "node scripts/check-nested-anchors.mjs",

--- a/scripts/build-static-site.mjs
+++ b/scripts/build-static-site.mjs
@@ -1,0 +1,57 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawn } from "node:child_process";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+
+/**
+ * The one build sequence that produces a deployable static export of the
+ * website: build:packages (dist output the CLI manifest and the website's
+ * typecheck both read from) -> build:cli-manifest (writes the gitignored
+ * manifest.json that packages/cli/src/index.ts statically imports, which
+ * the website's tsconfig pulls in during `next build`'s typecheck) -> the
+ * static export build itself. Skipping the first two steps on a fresh
+ * checkout fails with "Cannot find module './manifest.json'" even though
+ * it works on any machine that's built before and still has the file lying
+ * around.
+ *
+ * .github/workflows/pages.yml and scripts/verify-release.mjs both need this
+ * exact sequence — the former to deploy, the latter to catch static-export-only
+ * failures (`output: "export"` breaks a route that `next build` alone would
+ * pass) — so it lives here once instead of twice.
+ */
+export async function buildStaticSite({ env = process.env } = {}) {
+  const buildEnv = {
+    ...env,
+    NEXT_PUBLIC_STATIC_EXPORT: env.NEXT_PUBLIC_STATIC_EXPORT?.trim() || "true",
+    NEXT_PUBLIC_SITE_URL: env.NEXT_PUBLIC_SITE_URL?.trim() || "https://pinkyui.com",
+    NEXT_PUBLIC_BASE_PATH: env.NEXT_PUBLIC_BASE_PATH?.trim() || "",
+  };
+
+  await run(npmCommand, ["run", "build:packages"], buildEnv);
+  await run(npmCommand, ["run", "build:cli-manifest"], buildEnv);
+  await run(npmCommand, ["run", "build"], buildEnv);
+}
+
+function run(command, args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: root, env, stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`[build-static-site] ${command} ${args.join(" ")} failed (${code ?? signal})`));
+    });
+  });
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  try {
+    await buildStaticSite();
+    console.log("[build-static-site] static export build: PASS");
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile as execFileCallback, spawn } from "node:child_process";
 import { promisify } from "node:util";
+import { buildStaticSite } from "./build-static-site.mjs";
 
 const execFile = promisify(execFileCallback);
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -576,10 +577,10 @@ async function verifyExternalConsumer(infos, tarballs, tempRoot) {
  * failure — it happened this way once already: the opengraph-image route
  * built fine under `next build` but broke `output: "export"` outright
  * (missing `dynamic = "force-static""`), and nothing here would have
- * noticed short of reproducing .github/workflows/pages.yml's exact command.
- * This does that: same env vars as the real deploy (falling back to the
- * current ones so this keeps working through the pinkyui.com migration,
- * whenever pages.yml's env block changes).
+ * noticed short of reproducing .github/workflows/pages.yml's exact build.
+ * buildStaticSite() (scripts/build-static-site.mjs) is that exact build —
+ * pages.yml's deploy job calls the same function via `npm run
+ * build:static-site`, so this and the real deploy can't drift apart.
  *
  * The CNAME half of this is intentionally conditional on public/CNAME
  * existing, not just "run once the domain migrates": merging a CNAME file
@@ -590,15 +591,25 @@ async function verifyExternalConsumer(infos, tarballs, tempRoot) {
  * independent of whether DNS actually resolves there yet) — so the file
  * and the switch to a root basePath both land together, atomically, in the
  * dedicated migration change, not silently through this gate.
+ *
+ * This CNAME check itself stays here rather than moving into
+ * build-static-site.mjs: it's a release-gate assertion (does the artifact
+ * this repo is about to ship have the right domain marker in it?), not part
+ * of producing the build. build-static-site.mjs only knows how to build the
+ * site the same way everywhere; verifying the result is release-verification's
+ * job, same as every other assertX() in this file.
  */
 async function assertStaticExportBuild() {
-  const env = {
-    ...RELEASE_ENV,
-    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL?.trim() || "https://pinkyui.com",
-    NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH?.trim() || "",
-    NEXT_PUBLIC_STATIC_EXPORT: "true",
-  };
-  await run(npmCommand, ["run", "build"], { env });
+  // RELEASE_ENV always sets NEXT_PUBLIC_SITE_URL (falling back to
+  // pinky-ui.example.test, not pinkyui.com, when unset) for the rest of the
+  // release run's `npm run build` steps. buildStaticSite()'s own default of
+  // https://pinkyui.com — the value pages.yml's deploy job actually uses —
+  // only kicks in when the var is genuinely absent, so that fallback has to
+  // come from raw process.env here, not from RELEASE_ENV's already-defaulted
+  // copy, or CI would silently build against the wrong site URL.
+  const env = { ...RELEASE_ENV };
+  if (!process.env.NEXT_PUBLIC_SITE_URL?.trim()) delete env.NEXT_PUBLIC_SITE_URL;
+  await buildStaticSite({ env });
   console.log("[release] static export build: PASS");
 
   const publicCnamePath = path.join(root, "apps/website/public/CNAME");


### PR DESCRIPTION
## Summary
- Extract the build:packages → build:cli-manifest → static export build sequence, previously duplicated in .github/workflows/pages.yml and scripts/verify-release.mjs, into a single shared scripts/build-static-site.mjs (exported as `buildStaticSite({ env })`, also runnable directly via `npm run build:static-site`).
- pages.yml's deploy job now calls `npm run build:static-site` instead of listing the steps itself; verify-release.mjs's `assertStaticExportBuild()` imports and calls the same function, so the two paths can no longer drift apart the way issue #4 describes.
- Fixed a latent env-var bug surfaced while wiring this up: `assertStaticExportBuild()` was handing `RELEASE_ENV` straight through, whose `NEXT_PUBLIC_SITE_URL` always defaults to `pinky-ui.example.test` — so in CI (where the var is unset) the "shared" build was silently exercising the wrong site URL instead of `pinkyui.com`, defeating the parity this refactor is meant to guarantee. Fixed by deriving the override from raw `process.env`, same as the original code did.

Fixes #4

## Test plan
- [x] `npm run build:static-site` run locally end-to-end (full static export, 500+ pages, `apps/website/out/CNAME` produced)
- [x] Re-verified with `NEXT_PUBLIC_SITE_URL` unset (the ci.yml case) — resolves to `https://pinkyui.com`, matching pages.yml's job-level env
- [x] Confirmed pages.yml and verify-release.mjs now invoke the same code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)