### PR TITLE
docs+feat: clarify pre-npm install story in README and website hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Website: https://pinkyui.com
 
 ![Pinky UI hero preview](docs/hero.gif)
 
-**An open-source React interaction and UI system for modern interfaces.**
+**A React library for interactive motion.**
+
+> ⚠️ Source available — the `@pinky-ui/*` packages are not yet published to npm. Clone and run locally, or copy source directly.
 
 Pinky UI is an open-source collection of expressive React components, product systems and motion primitives built for interfaces that feel responsive, tactile and alive.
 
@@ -31,9 +33,10 @@ React · TypeScript · Tailwind CSS · Motion · Accessible · Open Source
 
 ## Get started
 
-Pinky UI is currently developed from source; the `@pinky-ui/*` packages have publish-like build
-metadata and packed artifacts, but are not published npm packages yet. After npm publication,
-the package READMEs will show the normal registry installation commands.
+### Try it locally
+
+This runs the demo website — the interaction wall, docs and playground — on your machine. It
+does not install any components into your own project; see "Use in your project" below for that.
 
 ```bash
 git clone https://github.com/florash/Pinky-UI.git
@@ -46,6 +49,13 @@ Open http://localhost:3000 for the interaction wall or /docs for the usage guide
 
 For a production build, set `NEXT_PUBLIC_SITE_URL` to the public `http` or `https` origin so
 canonical URLs, Open Graph metadata, sitemap and robots output point at the deployed site.
+
+### Use in your project
+
+The `@pinky-ui/*` packages have publish-like build metadata and packed artifacts, but are not
+published to npm yet — `npm install @pinky-ui/...` doesn't work today. Until then, copy the
+source you need directly from `packages/*` into your own project. Once the packages are
+published, this section will show the normal registry installation commands.
 
 ## Styling
 
@@ -138,13 +148,10 @@ dependency list is `motion`, `next`, `react` and `react-dom`.
 
 ## Skills
 
-Pinky UI ships **agent-readable interaction Skills**: **283 canonical Markdown recipes across
-284 public Skill routes** in `packages/skills`. One route is an intentional legacy alias kept
+Pinky UI ships **agent-readable interaction Skills**: **355 canonical Markdown recipes across
+356 public Skill routes** in `packages/skills`. One route is an intentional legacy alias kept
 for compatibility. The recipes cover individual items and system-level guidance on interaction
 density, reduced motion, landing-page motion, choosing a card, and composition.
-
-Five primitives (`spring`, `parallax`, `press-spring`, `cursor`, `glow`) do not
-have skills yet. They are public API, not internals.
 
 The website renders those files directly, so there is no second copy to fall out
 of date.

--- a/apps/website/src/components/home/hero.tsx
+++ b/apps/website/src/components/home/hero.tsx
@@ -4,9 +4,14 @@ import { FluidTabs, GlowBorder, JellyCard, MagneticButton } from "@pinky-ui/comp
 import { CursorGlow, subscribeToPointer, useMotionEnabled } from "@pinky-ui/primitives";
 import { useEffect, useRef } from "react";
 
-import { ArrowRight } from "@/components/site/icons";
+import { CodeBlock } from "@/components/site/code-block";
+import { ArrowRight, GitHubMark } from "@/components/site/icons";
 import { Container } from "@/components/site/layout";
 import { MagneticLink } from "@/components/site/magnetic-link";
+import { SITE } from "@/lib/site";
+
+const CLONE_COMMAND = `git clone https://github.com/florash/Pinky-UI.git
+cd Pinky-UI && npm install && npm run dev`;
 
 export function Hero() {
   return (
@@ -21,32 +26,38 @@ export function Hero() {
               Pinky UI
               <span className="h-px flex-1 bg-line" />
               v0.1
+              <span className="normal-case text-ink-400">Source available · npm coming soon</span>
             </p>
 
             {/*
-              The tagline carries the page, not the product name — the name is
-              in the header, the logo and the eyebrow above. What a first-time
-              visitor should remember is what the library does.
+              Developer-tool ordering: say what it is, then hand over code
+              that runs, then let tone follow. The tagline still carries the
+              page, not the product name — the name is in the header, the
+              logo and the eyebrow above.
             */}
             <h1 className="mt-6 max-w-xl text-[clamp(2.5rem,4.4vw,4rem)] leading-[0.96] tracking-[-0.055em] text-balance-tight">
-              UI that likes
+              A React library
               <br />
-              to move.
+              for interactive motion.
             </h1>
 
-            {/*
-              One sentence and one door. GitHub already sits in the header and
-              closes the page, so the hero does not need a second CTA competing
-              with the live surfaces beside it.
-            */}
             <p className="mt-5 max-w-sm text-base leading-relaxed text-ink-700">
-              An open-source React interaction system — real UI, already moving, ready to touch.
+              75 building blocks — 12 motion primitives, 35 components, 28 layouts. Every one has
+              a live preview and an import path.
             </p>
 
-            <div className="mt-7">
-              <MagneticLink href="/explore" size="lg">
-                Explore
+            <div className="mt-6">
+              <CodeBlock code={CLONE_COMMAND} label="shell" language="bash" className="max-w-sm" />
+            </div>
+
+            <div className="mt-7 flex flex-wrap items-center gap-3">
+              <MagneticLink href="/components" size="lg">
+                Browse Components
                 <ArrowRight className="size-4" />
+              </MagneticLink>
+              <MagneticLink href={SITE.github} variant="soft" size="lg" external>
+                <GitHubMark className="size-4" />
+                View on GitHub
               </MagneticLink>
             </div>
           </div>
@@ -146,24 +157,15 @@ function HeroStage() {
           <p className="font-mono text-[0.6875rem] tracking-[0.16em] text-ink-500 uppercase">
             Jelly Card
           </p>
+          <p className="mt-2 font-mono text-xs text-ink-500">elasticity 0.4 · intensity 0.2</p>
           <p className="mt-4 font-display text-2xl leading-tight font-semibold tracking-tight">
             Move across
             <br />
             this card.
           </p>
           <p className="mt-3 text-sm leading-relaxed text-ink-700">
-            The surface leans toward you, drifts a little, and settles on a spring.
+            Elastic lean, drift and settle — with squash and stretch on press.
           </p>
-          <div className="mt-7 flex items-center gap-3">
-            <span
-              aria-hidden
-              className="size-8 rounded-pill"
-              style={{
-                background: "linear-gradient(140deg, var(--color-blush-200), var(--color-cloud-200))",
-              }}
-            />
-            <span className="font-mono text-xs text-ink-500">elasticity 0.4 · intensity 0.2</span>
-          </div>
         </JellyCard>
 
         {/* Pointer-only, so it earns nothing on a touch screen and only makes


### PR DESCRIPTION
## Summary
- README: moved the "not yet on npm" caveat to a prominent line right under the tagline (was buried mid-paragraph), updated the one-line tagline to "A React library for interactive motion.", and split "Get started" into "Try it locally" (running the demo site) vs. "Use in your project" (no npm install yet, copy source directly).
- README: corrected stale Skills stats (283 canonical / 284 routes → 355 / 356, matching the current `packages/skills` tree) and removed a "5 primitives have no skill yet" line that's no longer true — all 12 do now. Registry item counts (314 total / 12 primitives / 35 components / 28 layouts / 37 effects / 32 experiences / 170 systems) were already accurate, left unchanged.
- Website hero (`apps/website/src/components/home/hero.tsx`): reordered to a dev-tool-style hierarchy (what it is → runnable code → tone) — new headline/subhead, a copyable `git clone && npm install && npm run dev` block (reusing the existing `CodeBlock` component), primary CTA renamed to "Browse Components" (→ `/components`), a new secondary "View on GitHub" CTA, an inline "Source available · npm coming soon" note by the version tag, and the Jelly Card demo's spec line (`elasticity 0.4 · intensity 0.2`) moved above its description instead of below.

No changes to color tokens, fonts, motion logic, or the header/nav structure.

## Test plan
- [x] `npm run dev`, checked hero at desktop and mobile viewports — renders correctly, no console errors
- [x] Verified `Browse Components` → `/components` and `View on GitHub` → the repo URl
- [x] `tsc -p apps/website/tsconfig.json --noEmit` and `eslint` on the changed file — both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)